### PR TITLE
Replace Delimiter params

### DIFF
--- a/src/BinaryFormatter.elm
+++ b/src/BinaryFormatter.elm
@@ -1,6 +1,6 @@
 module BinaryFormatter exposing (format)
 
-import Delimiter exposing (Params, format)
+import Delimiter exposing (format)
 
 
 interval : Int
@@ -11,7 +11,7 @@ interval =
 format : String -> String
 format value =
     String.padLeft (getLeftPadCount value) '0' value
-        |> Delimiter.format (Delimiter.Params interval " ")
+        |> Delimiter.format interval " "
 
 
 getLeftPadCount : String -> Int

--- a/src/Delimiter.elm
+++ b/src/Delimiter.elm
@@ -1,18 +1,18 @@
-module Delimiter exposing (..)
+module Delimiter exposing (format)
 
 
-type alias Params =
+type alias FormatParams =
     { interval : Int
     , string : String
     }
 
 
-format : Params -> String -> String
-format del str =
-    formatInterval del "" str
+format : Int -> String -> String -> String
+format interval delimiter formatStr =
+    formatInterval (FormatParams interval delimiter) "" formatStr
 
 
-formatInterval : Params -> String -> String -> String
+formatInterval : FormatParams -> String -> String -> String
 formatInterval del formatStr inStr =
     if (String.length inStr == 0) then
         formatStr

--- a/tests/Test/Delimiter.elm
+++ b/tests/Test/Delimiter.elm
@@ -10,12 +10,12 @@ tests =
     describe "Delimiter"
         [ describe "format"
             [ test "12 34 56" <|
-                \() -> Expect.equal "12 34 56" (format (Params 2 " ") "123456")
+                \() -> Expect.equal "12 34 56" (format 2 " " "123456")
             , test "123,456" <|
-                \() -> Expect.equal "123,456" (format (Params 3 ",") "123456")
+                \() -> Expect.equal "123,456" (format 3 "," "123456")
             , test "1,234,567" <|
-                \() -> Expect.equal "1,234,567" (format (Params 3 ",") "1234567")
+                \() -> Expect.equal "1,234,567" (format 3 "," "1234567")
             , test "0010 0111 0111 1111" <|
-                \() -> Expect.equal "0010 0111 0111 1111" (format (Params 4 " ") "0010011101111111")
+                \() -> Expect.equal "0010 0111 0111 1111" (format 4 " " "0010011101111111")
             ]
         ]


### PR DESCRIPTION
Replace Delimiter params with actual pieces since it ended up being more space to do the same work